### PR TITLE
Fix vue-terminal link

### DIFF
--- a/src/guide/extras/ways-of-using-vue.md
+++ b/src/guide/extras/ways-of-using-vue.md
@@ -56,4 +56,4 @@ Vue надає першокласні API для «рендерингу» про
 - Створюйте настільні програми за допомогою [Electron](https://www.electronjs.org/) або [Tauri](https://tauri.app)
 - Створюйте мобільні програми за допомогою [Ionic Vue](https://ionicframework.com/docs/vue/overview)
 - Створюйте настільні та мобільні додатки з однієї кодової бази за допомогою [Quasar](https://quasar.dev/)
-- Використовуйте [Custom Renderer API](/api/custom-renderer) Vue, щоб створювати користувацькі рендерери, націлені на [WebGL](https://troisjs.github.io/) або навіть на [термінал](https://github.com). /vue-terminal/vue-termui)!
+- Використовуйте [Custom Renderer API](/api/custom-renderer) Vue, щоб створювати користувацькі рендерери, націлені на [WebGL](https://troisjs.github.io/) або навіть на [термінал](https://github.com/vue-terminal/vue-termui). )!


### PR DESCRIPTION
Fixed github link for vue-terminal repository

- [x] Я ознайомлений(а) з [Правилами спільноти](https://github.com/vuejs-translations/docs-uk/wiki/Правила-спільноти) та зобов'язуюсь їх дотримуватись.
